### PR TITLE
Fix to also work with BSD date.

### DIFF
--- a/gh-furik
+++ b/gh-furik
@@ -2,7 +2,7 @@
 set -e
 
 FROM=`date +%FT00:00:00%z`
-TO=`date +%FT00:00:00%z -d tomorrow`
+TO=`date +%FT23:59:59%z`
 HOSTNAME="github.com"
 
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
The `-d` option specified with `date` seems to be an option that exists only for `GNU date`; the `date` installed by default on macOS is a `BSD date`, so this command cannot be used.

https://github.com/kenchan/gh-furik/blob/07f151e797065e37ca253e56c6bcf7c5e445989b/gh-furik#L5

(macOS)
```sh
$ date +%FT00:00:00%z -d tomorrow
date: illegal time format
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
```


Instead, I figured that specifying `23:59:59` in the `date` command would work with either date command.

(macOS)
```sh
$ date +%FT23:59:59%z
2022-04-18T23:59:59+0900
$ gdate +%FT23:59:59%z # require `brew install coreutils`
2022-04-18T23:59:59+0900
```