### PR TITLE
Migrate to GraphQL API for comprehensive activity tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The date range can be changed with `--from` and `--to`.
 gh furik --from 2022-04-01 --to 2022-04-10
 ```
 
-This extension uses the [GitHub Events API](https://docs.github.com/ja/rest/reference/activity#events). There is a limit to the amount of data that can be get with that API.
+This extension uses the [GitHub GraphQL API](https://docs.github.com/en/graphql) to fetch your activities including PR reviews, comments, and created issues/PRs with pagination support.
 
 ## Related Project
 

--- a/gh-furik
+++ b/gh-furik
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-FROM=`date +%FT00:00:00%z`
-TO=`date +%FT23:59:59%z`
+FROM=$(date -d "yesterday" +%Y-%m-%dT00:00:00Z)
+TO=$(date +%Y-%m-%dT23:59:59Z)
 HOSTNAME="github.com"
+ORG=""
+REPO=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -12,29 +14,324 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     --from)
-      FROM="$2"
+      FROM="${2}T00:00:00Z"
       shift
       ;;
     --to)
-      TO="$2"
+      TO="${2}T23:59:59Z"
+      shift
+      ;;
+    --org)
+      ORG="$2"
+      shift
+      ;;
+    --repo)
+      REPO="$2"
       shift
       ;;
   esac
   shift
 done
 
-JQ_QUERY="
-[
-  .[] |
-  select((.created_at >= \"$FROM\") and (.created_at <= \"$TO\") and (.type | startswith(\"Pull\") or startswith(\"Issue\"))) |
-  {\"type\": .type, \"repo\": .repo.name, \"title\": (.payload.pull_request // .payload.issue).title, \"url\": (.payload.review // .payload.comment // .payload.pull_request // .payload.issue).html_url}
-] | 
+TEMP_FILE=$(mktemp)
+trap "cp $TEMP_FILE /tmp/gh-furik-debug.json; rm -f $TEMP_FILE" EXIT
+
+# Fetch PR review comments
+gh api graphql --hostname "$HOSTNAME" -f from="$FROM" -f to="$TO" -f query='
+query($from: DateTime!, $to: DateTime!) {
+  viewer {
+    login
+    contributionsCollection(from: $from, to: $to) {
+      pullRequestReviewContributions(first: 100) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          pullRequestReview {
+            url
+            publishedAt
+            pullRequest {
+              title
+              repository {
+                nameWithOwner
+              }
+            }
+            comments(first: 100) {
+              nodes {
+                url
+                bodyText
+                publishedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+' | jq -r '
+.data.viewer.contributionsCollection.pullRequestReviewContributions.nodes[] |
+.pullRequestReview |
+{
+  type: "PullRequestReview",
+  repo: .pullRequest.repository.nameWithOwner,
+  title: .pullRequest.title,
+  url: .url,
+  created_at: .publishedAt
+} as $review |
+if (.comments.nodes | length) > 0 then
+  .comments.nodes[] | {
+    type: "PullRequestReviewComment",
+    repo: $review.repo,
+    title: $review.title,
+    url: .url,
+    created_at: .publishedAt
+  }
+else
+  $review
+end
+' >> "$TEMP_FILE"
+
+# Fetch Issue comments and PR comments
+CURSOR=""
+HAS_NEXT_PAGE="true"
+
+while [ "$HAS_NEXT_PAGE" = "true" ]; do
+  if [ -z "$CURSOR" ]; then
+    RESPONSE=$(gh api graphql --hostname "$HOSTNAME" -f query='
+query {
+  viewer {
+    login
+    issueComments(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        url
+        publishedAt
+        bodyText
+        issue {
+          title
+          url
+          repository {
+            nameWithOwner
+          }
+        }
+      }
+    }
+  }
+}
+')
+  else
+    RESPONSE=$(gh api graphql --hostname "$HOSTNAME" -f cursor="$CURSOR" -f query='
+query($cursor: String!) {
+  viewer {
+    login
+    issueComments(first: 100, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        url
+        publishedAt
+        bodyText
+        issue {
+          title
+          url
+          repository {
+            nameWithOwner
+          }
+        }
+      }
+    }
+  }
+}
+')
+  fi
+
+  # Filter only comments within date range
+  echo "$RESPONSE" | jq -r --arg from "$FROM" --arg to "$TO" '
+.data.viewer.issueComments.nodes[] |
+select(.publishedAt >= $from and .publishedAt <= $to) |
+{
+  type: (if (.url | contains("/pull/")) then "PullRequestComment" else "IssueComment" end),
+  repo: .issue.repository.nameWithOwner,
+  title: .issue.title,
+  url: .url,
+  created_at: .publishedAt
+}
+' >> "$TEMP_FILE"
+
+  HAS_NEXT_PAGE=$(echo "$RESPONSE" | jq -r '.data.viewer.issueComments.pageInfo.hasNextPage')
+  CURSOR=$(echo "$RESPONSE" | jq -r '.data.viewer.issueComments.pageInfo.endCursor')
+
+  # Exit when oldest comment is outside the range
+  OLDEST_DATE=$(echo "$RESPONSE" | jq -r '.data.viewer.issueComments.nodes[-1].publishedAt // empty')
+  if [ -n "$OLDEST_DATE" ] && [[ "$OLDEST_DATE" < "$FROM" ]]; then
+    break
+  fi
+
+  if [ -z "$CURSOR" ]; then
+    break
+  fi
+done
+
+# Fetch created Issues and PRs
+CURSOR=""
+HAS_NEXT_PAGE="true"
+
+while [ "$HAS_NEXT_PAGE" = "true" ]; do
+  if [ -z "$CURSOR" ]; then
+    RESPONSE=$(gh api graphql --hostname "$HOSTNAME" -f query='
+query {
+  viewer {
+    login
+    issues(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        url
+        title
+        createdAt
+        repository {
+          nameWithOwner
+        }
+      }
+    }
+    pullRequests(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        url
+        title
+        createdAt
+        repository {
+          nameWithOwner
+        }
+      }
+    }
+  }
+}
+')
+  else
+    RESPONSE=$(gh api graphql --hostname "$HOSTNAME" -f cursor="$CURSOR" -f query='
+query($cursor: String!) {
+  viewer {
+    login
+    issues(first: 100, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        url
+        title
+        createdAt
+        repository {
+          nameWithOwner
+        }
+      }
+    }
+    pullRequests(first: 100, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        url
+        title
+        createdAt
+        repository {
+          nameWithOwner
+        }
+      }
+    }
+  }
+}
+')
+  fi
+
+  # Filter Issues
+  echo "$RESPONSE" | jq -r --arg from "$FROM" --arg to "$TO" '
+.data.viewer.issues.nodes[] |
+select(.createdAt >= $from and .createdAt <= $to) |
+{
+  type: "Issue",
+  repo: .repository.nameWithOwner,
+  title: .title,
+  url: .url,
+  created_at: .createdAt
+}
+' >> "$TEMP_FILE"
+
+  # Filter Pull Requests
+  echo "$RESPONSE" | jq -r --arg from "$FROM" --arg to "$TO" '
+.data.viewer.pullRequests.nodes[] |
+select(.createdAt >= $from and .createdAt <= $to) |
+{
+  type: "PullRequest",
+  repo: .repository.nameWithOwner,
+  title: .title,
+  url: .url,
+  created_at: .createdAt
+}
+' >> "$TEMP_FILE"
+
+  ISSUE_HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.viewer.issues.pageInfo.hasNextPage')
+  PR_HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.viewer.pullRequests.pageInfo.hasNextPage')
+
+  if [ "$ISSUE_HAS_NEXT" = "true" ] || [ "$PR_HAS_NEXT" = "true" ]; then
+    HAS_NEXT_PAGE="true"
+    CURSOR=$(echo "$RESPONSE" | jq -r '.data.viewer.issues.pageInfo.endCursor // .data.viewer.pullRequests.pageInfo.endCursor')
+  else
+    HAS_NEXT_PAGE="false"
+  fi
+
+  # Exit when oldest item is outside the range
+  OLDEST_ISSUE=$(echo "$RESPONSE" | jq -r '.data.viewer.issues.nodes[-1].createdAt // empty')
+  OLDEST_PR=$(echo "$RESPONSE" | jq -r '.data.viewer.pullRequests.nodes[-1].createdAt // empty')
+
+  if ([ -n "$OLDEST_ISSUE" ] && [[ "$OLDEST_ISSUE" < "$FROM" ]]) || ([ -n "$OLDEST_PR" ] && [[ "$OLDEST_PR" < "$FROM" ]]); then
+    break
+  fi
+
+  if [ -z "$CURSOR" ]; then
+    break
+  fi
+done
+
+# Format and output results
+jq -rs '
 group_by(.repo) |
-map({repo: .[0].repo, activities: .}) |
-map(\"\n### \" + .repo +\"\n\", (.activities | group_by(.type, .url)[] | flatten | unique | map(\"- [\" + .type[0:-5] + \"](\" + .url + \"): \" + .title))) |
+map({
+  repo: .[0].repo,
+  activities: (
+    . |
+    group_by(.url) |
+    map(
+      sort_by(
+        if .type == "PullRequestReview" or .type == "PullRequestReviewComment" then 0
+        elif .type == "PullRequest" or .type == "Issue" then 1
+        elif .type == "IssueComment" or .type == "PullRequestComment" then 2
+        else 3
+        end
+      ) |
+      .[0]
+    ) |
+    sort_by(.created_at) |
+    reverse
+  )
+}) |
+sort_by(.repo) |
+map("\n### " + .repo +"\n", (.activities | map("- [" + .type + "](" + .url + "): " + .title))) |
 flatten |
-.[]"
-
-USER=$(gh api user -q .login --hostname "$HOSTNAME")
-
-exec gh api users/"$USER"/events --hostname "$HOSTNAME" --paginate -q "$JQ_QUERY"
+.[]
+  # Continue if either has next page
+' "$TEMP_FILE"


### PR DESCRIPTION
This PR migrates from the GitHub Events API to the GraphQL API to provide more comprehensive activity tracking.

## Changes

- Replace Events API queries with GraphQL API queries
- Add support for fetching PR review comments using `contributionsCollection` API
- Implement pagination for issues, PRs, and comments to handle large datasets
- Add `--org` and `--repo` parameters for future filtering capabilities
- Improve date handling for cross-platform compatibility (yesterday's date)
- Update README documentation to reflect GraphQL API usage