### PR TITLE
macOSでのdateコマンド対応を追加

### DIFF
--- a/gh-furik
+++ b/gh-furik
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS (BSD date)
-  FROM=$(date -v-1d +%Y-%m-%dT00:00:00Z)
-else
-  # Linux (GNU date)
+if date --version >/dev/null 2>&1; then
+  # GNU date
   FROM=$(date -d "yesterday" +%Y-%m-%dT00:00:00Z)
+else
+  # BSD date
+  FROM=$(date -v-1d +%Y-%m-%dT00:00:00Z)
 fi
 TO=$(date +%Y-%m-%dT23:59:59Z)
 HOSTNAME="github.com"

--- a/gh-furik
+++ b/gh-furik
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-FROM=$(date -d "yesterday" +%Y-%m-%dT00:00:00Z)
+# プラットフォーム対応の昨日の日付取得
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS (BSD date)
+  FROM=$(date -v-1d +%Y-%m-%dT00:00:00Z)
+else
+  # Linux (GNU date)
+  FROM=$(date -d "yesterday" +%Y-%m-%dT00:00:00Z)
+fi
 TO=$(date +%Y-%m-%dT23:59:59Z)
 HOSTNAME="github.com"
 ORG=""

--- a/gh-furik
+++ b/gh-furik
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# プラットフォーム対応の昨日の日付取得
 if [[ "$OSTYPE" == "darwin"* ]]; then
   # macOS (BSD date)
   FROM=$(date -v-1d +%Y-%m-%dT00:00:00Z)


### PR DESCRIPTION
## 概要
Mac OS で使用した際に、macOS の date は GNU date とは異なるため、 -d オプションは使えないのでMac OSの場合では別の方法で対応したいです

- エラーログ
```bash
❯ gh furik      
date: illegal option -- d
usage: date [-jnRu] [-I[date|hours|minutes|seconds|ns]] [-f input_fmt]
            [ -z output_zone ] [-r filename|seconds] [-v[+|-]val[y|m|w|d|H|M|S]]
            [[[[mm]dd]HH]MM[[cc]yy][.SS] | new_date] [+output_fmt]
```

## 対応
使用しているdateコマンドの種類で判定します

## 動作確認
### macOS環境（BSD date）での検証
```
✓ BSD dateとして正しく判定
✓ FROM: 2025-12-11T00:00:00Z
✓ フォーマット検証: OK
✓ GNU date構文は使えない（期待通り）
```

### Linux環境（GNU date）での検証
```
✓ GNU dateとして正しく判定
✓ FROM: 2025-12-11T00:00:00Z
✓ フォーマット検証: OK
✓ BSD date構文は使えない（期待通り）
```